### PR TITLE
FIX : Typo

### DIFF
--- a/store/admin.py
+++ b/store/admin.py
@@ -16,7 +16,7 @@ class ProfileInline(admin.StackedInline):
 # Extend User Model
 class UserAdmin(admin.ModelAdmin):
 	model = User
-	field = ["username", "first_name", "last_name", "email"]
+	fields = ["username", "first_name", "last_name", "email"]
 	inlines = [ProfileInline]
 
 # Unregister the old way


### PR DESCRIPTION
In the 24th video, in the admin.py file, the UserAdmin class mistakenly uses filed instead of fields. This causes all fields to be displayed in the admin panel.